### PR TITLE
Changes for Milestone 6: Added an async function to return the status…

### DIFF
--- a/framework/src/tests/PlaceOrder.spec.ts
+++ b/framework/src/tests/PlaceOrder.spec.ts
@@ -8,6 +8,19 @@ chai.should();
 describe("Positive and Negative scenarios for POST /store/order", () => {
   const storeService = new StoreService();
   
+  async function getStatusCodeFromGet(responseCreation: OrderResponse): Promise<number> {
+
+    let returnCode : undefined | number = undefined;
+    //console.log("creation : " + JSON.stringify(responseCreation));
+    const responseId = await storeService.getOrderById<OrderResponse>(responseCreation.id);
+    returnCode = responseId.status;
+    /*console.log("estatu: " + responseId.status);
+    console.log("get : " + JSON.stringify(responseId.data));
+    console.log("headers : " + JSON.stringify(responseId.headers));*/
+    
+    return returnCode; 
+  }
+  
   function validateResponseFieldsOrderCreation(response: OrderResponse, 
     orderSent: OrderModel, 
     formattedShipDate: string
@@ -35,9 +48,11 @@ describe("Positive and Negative scenarios for POST /store/order", () => {
     const formattedShipDate = response.data.shipDate.toString().split('T')[0];
     if (!formattedShipDate) throw new Error("Ship Date is not defined");
     const orderResponse: OrderResponse = response.data;
-    console.log(response.data);
+    //console.log(response.data);
     response.status.should.equal(200, JSON.stringify(response.data));
     validateResponseFieldsOrderCreation(orderResponse,order,formattedShipDate);
+    const statusCode = await getStatusCodeFromGet(response.data);
+    response.status.should.equal(200, statusCode.toString());
   });
 
   it("@Smoke - Place Order correctly with valid values and Status = Delivered", async () => {
@@ -56,6 +71,8 @@ describe("Positive and Negative scenarios for POST /store/order", () => {
     const orderResponse: OrderResponse = response.data;
     response.status.should.equal(200, JSON.stringify(response.data));
     validateResponseFieldsOrderCreation(orderResponse,order,formattedShipDate);
+    const statusCode = await getStatusCodeFromGet(response.data);
+    response.status.should.equal(200, statusCode.toString());
   });
 
   it("@Smoke - Place Order correctly with valid values and Status = Approved", async () => {
@@ -74,6 +91,8 @@ describe("Positive and Negative scenarios for POST /store/order", () => {
     const orderResponse: OrderResponse = response.data;
     response.status.should.equal(200, JSON.stringify(response.data));
     validateResponseFieldsOrderCreation(orderResponse, order, formattedShipDate);
+    const statusCode = await getStatusCodeFromGet(response.data);
+    response.status.should.equal(200, statusCode.toString());
   });
 
   it("@Smoke - should place order with complete = false", async () => {
@@ -92,6 +111,8 @@ describe("Positive and Negative scenarios for POST /store/order", () => {
     const orderResponse: OrderResponse = response.data;
     response.status.should.equal(200, JSON.stringify(response.data));
     validateResponseFieldsOrderCreation(orderResponse, order, formattedShipDate);
+    const statusCode = await getStatusCodeFromGet(response.data);
+    response.status.should.equal(200, statusCode.toString());
   });
 
   it("@Smoke - should place order with future ship date", async () => {
@@ -110,6 +131,8 @@ describe("Positive and Negative scenarios for POST /store/order", () => {
     const orderResponse: OrderResponse = response.data;
     response.status.should.equal(200, JSON.stringify(response.data));
     validateResponseFieldsOrderCreation(orderResponse, order, formattedShipDate);
+    const statusCode = await getStatusCodeFromGet(response.data);
+    response.status.should.equal(200, statusCode.toString());
   });
 
   it("@Smoke - should place order with past ship date", async () => {
@@ -128,6 +151,8 @@ describe("Positive and Negative scenarios for POST /store/order", () => {
     const orderResponse: OrderResponse = response.data;
     response.status.should.equal(200, JSON.stringify(response.data));
     validateResponseFieldsOrderCreation(orderResponse, order, formattedShipDate);
+    const statusCode = await getStatusCodeFromGet(response.data);
+    response.status.should.equal(200, statusCode.toString());
   });
 
   

--- a/framework/src/tests/PlaceOrder.spec.ts
+++ b/framework/src/tests/PlaceOrder.spec.ts
@@ -11,12 +11,8 @@ describe("Positive and Negative scenarios for POST /store/order", () => {
   async function getStatusCodeFromGet(responseCreation: OrderResponse): Promise<number> {
 
     let returnCode : undefined | number = undefined;
-    //console.log("creation : " + JSON.stringify(responseCreation));
     const responseId = await storeService.getOrderById<OrderResponse>(responseCreation.id);
     returnCode = responseId.status;
-    /*console.log("estatu: " + responseId.status);
-    console.log("get : " + JSON.stringify(responseId.data));
-    console.log("headers : " + JSON.stringify(responseId.headers));*/
     
     return returnCode; 
   }
@@ -48,7 +44,6 @@ describe("Positive and Negative scenarios for POST /store/order", () => {
     const formattedShipDate = response.data.shipDate.toString().split('T')[0];
     if (!formattedShipDate) throw new Error("Ship Date is not defined");
     const orderResponse: OrderResponse = response.data;
-    //console.log(response.data);
     response.status.should.equal(200, JSON.stringify(response.data));
     validateResponseFieldsOrderCreation(orderResponse,order,formattedShipDate);
     const statusCode = await getStatusCodeFromGet(response.data);


### PR DESCRIPTION
# Pull Request Template

## Description

For the create Order tests, I've added a call to a new async function which is invoked after an Order has been created. That async function returns the status code of the GET call, using the newly created ID from the order.

Regarding Step 4, step 4 says "Since the test should fail, follow step 4 in MIlestone 5 for handling it.". I don't see why the test should fail. 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)